### PR TITLE
Rendering records page

### DIFF
--- a/controller/api/index.js
+++ b/controller/api/index.js
@@ -2,10 +2,10 @@ const router = require('express').Router()
 
 const FDARoutes = require('./FDARoutes.js')
 const userRoutes = require('./userRoutes.js')
-// const saveRoutes = require('./savedRecallsRoutes.js')
+const saveRoutes = require('./savedRecallsRoutes')
 
 router.use('/FDARoutes', FDARoutes)
 router.use('/users', userRoutes)
-// router.use('/', saveRoutes)
+router.use('/records', saveRoutes)
 
 module.exports = router

--- a/controller/api/savedRecallsRoutes.js
+++ b/controller/api/savedRecallsRoutes.js
@@ -15,7 +15,7 @@ router.post('/', async (req, res) => {
   }
 })
 
-// View a list of past recalls
+// View a list of past recalls (route : /api/records)
 router.get('/', async (req, res) => {
   try {
     const recallsData = await Recall.findAll({

--- a/controller/api/userRoutes.js
+++ b/controller/api/userRoutes.js
@@ -2,6 +2,7 @@ const express = require('express')
 const router = express.Router()
 const { User } = require('../../model')
 const { UserManufacturer } = require('../../model')
+const withAuth = require('../../utilities/auth')
 
 // Signup a new user
 router.post('/signup', async (req, res) => {
@@ -55,7 +56,7 @@ router.post('/logout', (req, res) => {
 })
 
 // add a new manufacturer
-router.post('/addManufacturer', (req, res) => {
+router.post('/addManufacturer', withAuth, (req, res) => {
   try {
     const newManufacturer = UserManufacturer.create({
       ...req.body,
@@ -64,6 +65,28 @@ router.post('/addManufacturer', (req, res) => {
     res.status(200).json(newManufacturer)
   } catch (err) {
     res.status(400).json(err)
+  }
+})
+
+// delete a manufacturer
+router.delete('/:id', withAuth, async (req, res) => {
+  try {
+    const manufacturerData = await UserManufacturer.destroy({
+      // we are deleting the usermanufacturer relationship which has the id associated with the manufacturer we clicked to delete which is also associated with our user who is signed in
+      where: {
+        id: req.params.id,
+        user_id: req.session.user_id
+      }
+    })
+
+    if (!manufacturerData) {
+      res.status(404).json({ message: 'No post was found with this id.' })
+      return
+    }
+
+    res.status(200).json(manufacturerData)
+  } catch (err) {
+    res.status(500).json(err)
   }
 })
 module.exports = router

--- a/public/js/addManufacturer.js
+++ b/public/js/addManufacturer.js
@@ -1,4 +1,4 @@
-let manufacturer_name;
+let manufacturer_name
 const addManufacturerButtonHandler = async (event) => {
   event.preventDefault()
   manufacturer_name = document.querySelector('#manufacturer-name').value.trim()
@@ -17,4 +17,25 @@ const addManufacturerButtonHandler = async (event) => {
     }
   }
 }
+
+const deleteManufacButtonHandler = async (event) => {
+  if (event.target.hasAttribute('data-id')) {
+    const id = event.target.getAttribute('data-id')
+
+    const response = await fetch(`/api/users/${id}`, {
+      method: 'DELETE'
+    })
+
+    if (response.ok) {
+      location.reload()
+    } else {
+      alert('Failed to delete the manufacturer.')
+    }
+  }
+}
 document.querySelector('#submit-manufacturer').addEventListener('click', addManufacturerButtonHandler)
+
+const deleteBtn = document.querySelectorAll('.delete-manuf-btn')
+for (i of deleteBtn) {
+  i.addEventListener('click', deleteManufacButtonHandler)
+}

--- a/seeds/recall.json
+++ b/seeds/recall.json
@@ -4,12 +4,14 @@
         "recall_number" : "F-0276-2017",
         "comment" : "Located the packages and threw them out.",
         "reason_for_recall" : "Recall initiated as a precautionary measure due to potential risk of product contamination with Burkholderia cepacia.",
+        "product_description": "Nutritional supplements",
         "user_id": 1
     },
     {
         "recalling_firm" : "Phizer LLC",
         "recall_number" : "F-0276-2035",
         "comment" : "Located the packages and discarded.",
+        "product_description": "Nutritional supplements",
         "reason_for_recall" : "FreshPoint South Florida is recalling sliced fresh yellow onions and salsa products processed using yellow onions sourced from Gills Onions, LLC which were recalled for Listeria monocytogenes.",
         "user_id": 2
     },
@@ -17,6 +19,7 @@
         "recalling_firm" : "CocaCola INC",
         "recall_number" : "F-0276-1876",
         "comment" : "Located the packages and discarded.",
+        "product_description": "Coke Zero canned sodas",
         "reason_for_recall" : "Pure Planet Organic Parasite Cleanse;  Net Wt. 174g Glass Jar;  Finished Product Item # 52700    Manufactured and Distributed by:  Pure Planet,  Rancho Dominguez, CA",
         "user_id": 3
     }

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -22,7 +22,7 @@
           <!-- Conditionally render login or logout links -->
           {{#if logged_in}}
             <a href="/profile">profile</a>
-            <a href="/records">records</a>
+            <a href="/api/records">records</a>
             <a href="/api/FDARoutes">see-recalls</a>
             |
             <button class="no-button" id="logout">logout</button>

--- a/views/profile.handlebars
+++ b/views/profile.handlebars
@@ -34,7 +34,7 @@
       {{manufacturer.manufacturer_name}}
       </div>
       <div class="col-md-4">
-        <button class="btn btn-sm btn-danger" data-id="{{manufacturer.id}}">DELETE</button>
+        <button class="btn btn-sm btn-danger delete-manuf-btn" data-id="{{manufacturer.id}}">DELETE</button>
       </div>
     </div>
     {{/each}}

--- a/views/records.handlebars
+++ b/views/records.handlebars
@@ -3,22 +3,24 @@
   <div class="col-md-5">
     <h2>
       <!-- Display the recall information -->
-      
-      <a href="/recall/{{recall.id}}">{{recall.recalling_firm}}</a>
+     {{recall.recalling_firm}}'s Recall
     </h2>
-    <p>
+    
       <!-- Display more information -->
+      <h4>Recall Number: {{recall.recall_number}}</h4>
+      <h4>Product: {{recall.product_description}}</h4>
+    <h5>
       Reason: {{recall.reason_for_recall}}
-    </p>
-    <p>Created on {{recall.date_created}}</p>
+    </h5>
+    <p>This record was created on {{recall.date_created}}</p>
   </div>
   <div class="col-md-7">
     <p>
       {{recall.product_description}}
     </p>
 
-    <p>User comments: {{recall.comments}}</p>
-    <p>{{recall.user.companyName}}</p>
+    <p>User comments: {{recall.comment}}</p>
+    <p>by {{recall.user.companyName}}</p>
   </div>
 </div>
 {{/each}}


### PR DESCRIPTION
I added product_descriptions to our seeded data to more closely resemble the fields we are saving to the model, I linked the navbar see-records link to the /api/records/ route so that it will automatically render records onto records page, and did a bit of reformatting